### PR TITLE
新規セクション開発

### DIFF
--- a/sections/featured-collection-custom.liquid
+++ b/sections/featured-collection-custom.liquid
@@ -1,0 +1,281 @@
+{%- assign per_row = section.settings.per_row -%}
+{%- assign product_limit = per_row | times: section.settings.rows -%}
+
+{%- if section.settings.divider -%}<div class="section--divider">{%- endif -%}
+
+<div
+  id="CollectionSection-{{ section.id }}"
+  data-section-id="{{ section.id }}"
+  data-section-type="featured-collection">
+  {%- if section.settings.title != blank -%}
+    <div class="page-width">
+      <div class="section-header{% if section.settings.view_all %}{% unless settings.type_headers_align_text %} section-header--with-link{% endunless %}{% endif %}">
+        <h2 class="section-header__title">
+          {{ section.settings.title }}
+        </h2>
+        {%- if section.settings.view_all and section.settings.rows == 1 -%}
+          <a href="{{ collections[section.settings.home_featured_products].url }}" class="btn btn--secondary btn--small section-header__link">{{ 'collections.general.all_of_collection' | t }}</a>
+        {%- endif -%}
+      </div>
+    </div>
+  {%- endif -%}
+
+  {%- unless section.blocks == blank -%}
+    <ul class="collection-switch js-change-collection">
+      {% for block in section.blocks %}
+        {%- assign collection = block.settings.collection -%}
+      <li id="collection-switch-{{ collection.id }}" {% if forloop.first %}class="--active"{%- endif -%} onclick="changeCollection('{{ collection.id }}')">{{ block.settings.title }}</li>
+      {% endfor %}
+    </ul>
+    {%- endunless -%}
+
+  <div class="page-width{% if section.settings.mobile_scrollable %} page-width--flush-small{% endif %}">
+    <div{% if section.settings.mobile_scrollable %} class="grid-overflow-wrapper"{% endif %}>
+      <div class="grid grid--uniform"{% if section.settings.mobile_scrollable %} data-aos="overflow__animation"{% endif %}>
+        {%- liquid
+          assign grid_item_width = 'small--one-half medium-up--one-third'
+
+          case per_row
+            when 1
+              assign grid_item_width = ''
+            when 2
+              assign grid_item_width = 'medium-up--one-half'
+            when 3
+              assign grid_item_width = 'small--one-third medium-up--one-third'
+            when 4
+              assign grid_item_width = 'small--one-half medium-up--one-quarter'
+            when 5
+              assign grid_item_width = 'small--one-half medium-up--one-fifth'
+          endcase
+        -%}
+
+        {%- if section.blocks == blank -%}
+
+          {%- unless emptyState -%}
+            {%- assign emptyState = true -%}
+          {%- endunless -%}
+
+          <div class="grid__item">
+            <div class="grid grid--uniform">
+              {%- for i in (1..product_limit) -%}
+                <div class="grid__item grid-product {{ grid_item_width }}" data-aos="row-of-{{ per_row }}">
+                  <div class="grid-product__content">
+                    <a href="{{ product.url | within: collection }}" class="grid-product__link">
+                      <div class="grid-product__image-mask">
+                        {%- capture current -%}{% cycle 1, 2, 3, 4, 5, 6 %}{%- endcapture -%}
+                        <div class="image-wrap">{{ 'product-' | append: current | placeholder_svg_tag: 'placeholder-svg' }}</div>
+                      </div>
+                      <div class="grid-product__meta">
+                        <div class="grid-product__title">{{ 'home_page.onboarding.product_title' | t }}</div>
+                        <div class="grid-product__price">$29</div>
+                      </div>
+                    </a>
+                  </div>
+                </div>
+              {%- endfor -%}
+            </div>
+          </div>
+
+        {%- else -%}
+
+        <div class="js-display-collection">
+          {% for block in section.blocks %}
+            {%- assign collection = block.settings.collection -%}
+          <div id="collection-{{ collection.id }}" class="collection-product__list" {% if forloop.first == false %}style="display: none;"{%- endif -%}>
+              {%- for product in collection.products limit: product_limit -%}
+                {%- render 'product-grid-item',
+                  product: product,
+                  collection: collection,
+                  per_row: per_row,
+                  grid_item_width_custom: grid_item_width,
+                  quick_shop_enable: settings.quick_shop_enable
+                -%}
+              {%- endfor -%}
+  
+              {%- if section.settings.view_all -%}
+  
+                {%- if section.settings.rows > 1 and collection.products_count > product_limit  -%}
+                  <div class="grid__item text-center{% if section.settings.mobile_scrollable %} small--hide{% endif %}">
+                    <a href="{{ collection.url }}" class="btn">{{ 'collections.general.all_of_collection' | t }}</a>
+                  </div>
+                {%- endif -%}
+  
+                {%- if section.settings.mobile_scrollable -%}
+                  <div class="grid__item grid__item--view-all text-center {{ grid_item_width }} medium-up--hide">
+                    <a href="{{ collection.url }}" class="grid-product__see-all">
+                      {{ 'collections.general.view_all_products_html' | t: count: collection.products_count }}
+                    </a>
+                  </div>
+                {%- endif -%}
+  
+              {%- endif -%}
+  
+            </div>
+          {% endfor %}
+
+        </div>
+
+        {%- endif -%}
+      </div>
+    </div>
+  </div>
+</div>
+
+{%- if section.settings.divider -%}</div>{%- endif -%}
+
+<style>
+  .collection-switch {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-evenly;
+    max-width: 947px;
+    margin: 0 auto 46px;
+    list-style: none;
+  }
+
+  .collection-switch li {
+    font-weight: normal;
+    font-size: 14px;
+    line-height: 20px;
+    letter-spacing: 0.1em;
+    width: 100px;
+    cursor: pointer;
+    position: relative;
+    text-align: center;
+  }
+
+  .collection-switch li.--active::after {
+    content: "";
+    position: absolute;
+    display: block;
+    width: 70%;
+    height: 2px;
+    background-color: #000;
+    bottom: -5px;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  @media only screen and (max-width: 768px) {
+    .collection-switch {
+      overflow-x: auto;
+      white-space: nowrap;
+      -webkit-overflow-scrolling: touch;
+      background: #EFEDE9;
+      height: 35px;
+      justify-content: initial;
+      -ms-overflow-style: none;
+      scrollbar-width: none;
+      margin-bottom: 21px;
+    }
+
+    .collection-switch::-webkit-scrollbar {
+      display: none;
+    }
+
+    .collection-switch li {
+        display: inline-block;
+        margin: 0 18px;
+        padding-top: 7px;
+        font-size: 12px;
+        line-height: 17px;
+        letter-spacing: 0.1em;
+    }
+
+    .collection-switch li.--active::after {
+      width: 80%;
+      bottom: 5px;
+    }
+  }
+
+  
+</style>
+
+<script>
+  function changeCollection(category){
+    $('.js-display-collection > div').each(function(index, element){
+      element.style.display = "none";
+    })
+    $('.js-change-collection > li').each(function(index, element){
+      if(element.classList){
+        element.classList.remove("--active");
+      }
+    })
+    $(`#collection-${category}`).show();
+    $(`#collection-switch-${category}`)[0].classList.add("--active");
+  }
+</script>
+
+{% schema %}
+{
+  "name": "Featured Collections",
+  "class": "index-section",
+  "settings": [
+    {
+      "type": "text",
+      "id": "title",
+      "label": "t:sections.featured-collection.settings.title.label",
+      "default": "Featured collection"
+    },
+    {
+      "type": "range",
+      "id": "per_row",
+      "label": "t:sections.featured-collection.settings.per_row.label",
+      "default": 4,
+      "min": 1,
+      "max": 5,
+      "step": 1
+    },
+    {
+      "type": "range",
+      "id": "rows",
+      "label": "t:sections.featured-collection.settings.rows.label",
+      "default": 1,
+      "min": 1,
+      "max": 5,
+      "step": 1
+    },
+    {
+      "type": "checkbox",
+      "id": "mobile_scrollable",
+      "label": "t:sections.featured-collection.settings.mobile_scrollable.label",
+      "default": true
+    },
+    {
+      "type": "checkbox",
+      "id": "view_all",
+      "label": "t:sections.featured-collection.settings.view_all.label",
+      "default": true
+    },
+    {
+      "type": "checkbox",
+      "id": "divider",
+      "label": "t:sections.featured-collection.settings.divider.label",
+      "default": false
+    }
+  ],
+  "blocks": [
+    {
+      "type": "collection",
+      "name": "Collection",
+      "settings": [
+        {
+          "type": "collection",
+          "id": "collection",
+          "label": "Collection"
+        },
+        {
+          "type": "text",
+          "id": "title",
+          "label": "Heading"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Featured Collections"
+    }
+  ]
+}
+{% endschema %}

--- a/snippets/product-grid-item.liquid
+++ b/snippets/product-grid-item.liquid
@@ -11,20 +11,24 @@ Arguments
     assign per_row = 4
   endunless
 
-  case per_row
-    when 1
-      assign grid_item_width = ''
-    when 2
-      assign grid_item_width = 'medium-up--one-half'
-    when 3
-      assign grid_item_width = 'small--one-half medium-up--one-third'
-    when 4
-      assign grid_item_width = 'small--one-half medium-up--one-quarter'
-    when 5
-      assign grid_item_width = 'small--one-half medium-up--one-fifth'
-    when 6
-      assign grid_item_width = 'small--one-half medium-up--one-sixth'
-  endcase
+  if grid_item_width_custom == blank
+    case per_row
+      when 1
+        assign grid_item_width = ''
+      when 2
+        assign grid_item_width = 'medium-up--one-half'
+      when 3
+        assign grid_item_width = 'small--one-half medium-up--one-third'
+      when 4
+        assign grid_item_width = 'small--one-half medium-up--one-quarter'
+      when 5
+        assign grid_item_width = 'small--one-half medium-up--one-fifth'
+      when 6
+        assign grid_item_width = 'small--one-half medium-up--one-sixth'
+    endcase
+  else
+    assign grid_item_width = grid_item_width_custom
+  endif
 
   assign on_sale = false
   if product.compare_at_price > product.price
@@ -49,7 +53,7 @@ Arguments
   endif
 -%}
 
-<div class="grid__item grid-product {{ grid_item_width }}{% if quick_shop_enable %} grid-product__has-quick-shop{% endif %}" data-aos="row-of-{{ per_row }}" data-product-handle="{{ product.handle }}" data-product-id="{{ product.id }}">
+<div class="grid__item grid-product  {{ grid_item_width }}{% if quick_shop_enable %} grid-product__has-quick-shop{% endif %}" data-aos="row-of-{{ per_row }}" data-product-handle="{{ product.handle }}" data-product-id="{{ product.id }}">
   <div class="grid-product__content">
     {%- if has_custom_label -%}
       <div class="grid-product__tag grid-product__tag--custom">

--- a/templates/cart.json
+++ b/templates/cart.json
@@ -4,7 +4,7 @@
       "type": "apps",
       "blocks": {
         "98597827-5930-45af-b03f-6c5ec6564d3f": {
-          "type": "shopify:\/\/apps\/monk-cart-upsell-free-gift\/blocks\/embedded-cart-page-cvb\/e949adb6-87ca-4b97-8f31-0e51bf507f2d",
+          "type": "shopify:\/\/apps\/monk-cross-sell-free-gift\/blocks\/embedded-cart-page-cvb\/e949adb6-87ca-4b97-8f31-0e51bf507f2d",
           "settings": {
           }
         }

--- a/templates/index.json
+++ b/templates/index.json
@@ -151,6 +151,101 @@
         "space_around": true
       }
     },
+    "3a3000f9-7b79-4b2a-a443-65cc4a3661bd": {
+      "type": "featured-collection-custom",
+      "blocks": {
+        "1163872d-94a3-4f11-8ffa-635cf66165d4": {
+          "type": "collection",
+          "settings": {
+            "collection": "new-item-新商品",
+            "title": "NEW ITEM"
+          }
+        },
+        "d1050def-2e77-4590-9c8e-545ebbb4dcc7": {
+          "type": "collection",
+          "settings": {
+            "collection": "ranking-ランキング",
+            "title": "RANKING"
+          }
+        },
+        "427b68b2-2179-4495-8b1e-afaeee3ccc75": {
+          "type": "collection",
+          "settings": {
+            "collection": "tops-トップス",
+            "title": "TOPS"
+          }
+        },
+        "659b2c49-ded8-4e2f-a3eb-849e3ecc4958": {
+          "type": "collection",
+          "settings": {
+            "collection": "bottoms-ボトムス",
+            "title": "BOTTOMS"
+          }
+        },
+        "80c80e95-d9d0-4021-aa89-4a931e5763be": {
+          "type": "collection",
+          "settings": {
+            "collection": "hat-帽子",
+            "title": "HAT"
+          }
+        },
+        "baae5a34-c379-46f7-985e-2108e032f82a": {
+          "type": "collection",
+          "settings": {
+            "collection": "shoes-シューズ",
+            "title": "SHOES"
+          }
+        },
+        "75a19b2d-6894-4100-b176-3546a5e529b1": {
+          "type": "collection",
+          "settings": {
+            "collection": "setup-セットアップ",
+            "title": "SETUP"
+          }
+        },
+        "62cbe5e5-f72d-41d8-b019-a4911bf7b925": {
+          "type": "collection",
+          "settings": {
+            "collection": "ピックアップアイテム",
+            "title": "PICKUP"
+          }
+        },
+        "cf350b98-b35f-4a14-9ca0-e51e67ab5ae5": {
+          "type": "collection",
+          "settings": {
+            "collection": "goods-グッズ",
+            "title": "GOODS"
+          }
+        },
+        "9ecb6238-2979-41cf-89c6-348e88fb3a55": {
+          "type": "collection",
+          "settings": {
+            "collection": "autumn-collection",
+            "title": "2023 S\/S"
+          }
+        }
+      },
+      "block_order": [
+        "1163872d-94a3-4f11-8ffa-635cf66165d4",
+        "d1050def-2e77-4590-9c8e-545ebbb4dcc7",
+        "427b68b2-2179-4495-8b1e-afaeee3ccc75",
+        "659b2c49-ded8-4e2f-a3eb-849e3ecc4958",
+        "80c80e95-d9d0-4021-aa89-4a931e5763be",
+        "baae5a34-c379-46f7-985e-2108e032f82a",
+        "75a19b2d-6894-4100-b176-3546a5e529b1",
+        "62cbe5e5-f72d-41d8-b019-a4911bf7b925",
+        "cf350b98-b35f-4a14-9ca0-e51e67ab5ae5",
+        "9ecb6238-2979-41cf-89c6-348e88fb3a55"
+      ],
+      "settings": {
+        "title": "Featured collection",
+        "per_row": 3,
+        "rows": 3,
+        "mobile_scrollable": false,
+        "view_all": true,
+        "divider": true
+      }
+    },
     "16481865815fb2d6f1": {
       "type": "featured-collection",
       "settings": {
@@ -440,6 +535,7 @@
     "slideshow",
     "1648471921d1ee2d3a",
     "6662337a-695f-41cd-b34a-f5a3fcf0febe",
+    "3a3000f9-7b79-4b2a-a443-65cc4a3661bd",
     "16481865815fb2d6f1",
     "3265b721-a445-4fd3-9731-0a2fb64db525",
     "823858a8-ebea-47a3-8629-7b096a368867",


### PR DESCRIPTION
■実装内容
カテゴリ別に3列3行でコレクションを表示させる（カテゴリをクリックでそのカテゴリの一覧に切り替える）

■挙動
・PC, SPどちらも3×3で表示
・9商品以上存在するコレクションは下部に「全て見る」ボタンを表示

■プレビュー
下記URLからご確認ください。
https://ffug45cfaga2wedh-66858942775.shopifypreview.com