### PR TITLE
スマホ版での不具合について修正

### DIFF
--- a/sections/featured-collection-custom.liquid
+++ b/sections/featured-collection-custom.liquid
@@ -160,13 +160,11 @@
     .collection-switch {
       overflow-x: auto;
       white-space: nowrap;
-      -webkit-overflow-scrolling: touch;
       background: #EFEDE9;
       height: 35px;
       justify-content: initial;
-      -ms-overflow-style: none;
-      scrollbar-width: none;
       margin-bottom: 21px;
+      padding-right: 15px;
     }
 
     .collection-switch::-webkit-scrollbar {
@@ -174,7 +172,6 @@
     }
 
     .collection-switch li {
-        display: inline-block;
         margin: 0 18px;
         padding-top: 7px;
         font-size: 12px;


### PR DESCRIPTION
一部のデバイスでカテゴリーをタップするとタップしたカテゴリーが非表示になるという不具合が発生していたため、その不具合を修正。